### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,6 @@
 name: Build and Test Library
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/EByte_LoRa_E220_Series_Library/security/code-scanning/9](https://github.com/Alteriom/EByte_LoRa_E220_Series_Library/security/code-scanning/9)

To fix this problem, add an explicit `permissions` block to the workflow to restrict the GitHub Actions token to the minimal set required by the jobs. Since all jobs appear only to require read access to the repository contents, specifying `contents: read` at the workflow root will ensure minimal privilege for all jobs, unless a job needs more (in which case, elevate as narrowly as possible at the job level).

Specifically:
- Edit `.github/workflows/build-test.yml`
- Add the block:
    ```yaml
    permissions:
      contents: read
    ```
  after the `name` block and before the `on:` block (conventionally right after the workflow's name).
- No new imports/definitions/etc. are required for this YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
