### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-platformio.yml
+++ b/.github/workflows/test-platformio.yml
@@ -1,4 +1,6 @@
 name: Test PlatformIO Library
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/EByte_LoRa_E220_Series_Library/security/code-scanning/10](https://github.com/Alteriom/EByte_LoRa_E220_Series_Library/security/code-scanning/10)

To fix the problem, add a `permissions` block granting only the minimal necessary permissions for the job(s). Since the jobs only read repository contents (source files needed for build/test), the minimal permission set is likely just `contents: read`. The best location for this block is directly beneath the workflow name declaration (at the root), which sets this for all jobs unless overridden locally. Edit `.github/workflows/test-platformio.yml` by inserting:

```yaml
permissions:
  contents: read
```

on the line after `name: Test PlatformIO Library` (i.e., after line 1). This change does not affect any existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
